### PR TITLE
Remove "X-Custom-IP-Authorization" because custom Burp/Port Swigger h…

### DIFF
--- a/ipsourcebypass.py
+++ b/ipsourcebypass.py
@@ -18,7 +18,7 @@ banner = "[~] IP source bypass using HTTP headers, v1.2\n"
 
 BYPASS_HEADERS = [
     'Access-Control-Allow-Origin', 'Client-IP', 'Forwarded', 'Forwarded-For', 'Forwarded-For-IP', 'Origin',
-    'X-Client-IP', 'X-Custom-IP-Authorization', 'X-Forwarded', 'X-Forwarded-By', 'X-Forwarded-For',
+    'X-Client-IP', 'X-Forwarded', 'X-Forwarded-By', 'X-Forwarded-For',
     'X-Forwarded-For-Original', 'X-Forwarded-Host', 'X-Forwarder-For', 'X-Originating-IP', 'X-Remote-Addr',
     'X-Remote-IP', "CF-Connecting-Ip", "X-Real-IP", "True-Client-IP"
 ]


### PR DESCRIPTION
Seems that "X-Custom-IP-Authorization" is a custom header only used for a Port Swigger lab.
Ref : https://twitter.com/albinowax/status/1587800171051503617