### PR TITLE
remove print of undeclared variable

### DIFF
--- a/ipsourcebypass.py
+++ b/ipsourcebypass.py
@@ -218,7 +218,6 @@ def parseArgs():
 
 
 if __name__ == '__main__':
-    print(banner)
 
     options = parseArgs()
     try:


### PR DESCRIPTION
`banner` variable has been removed in commit dcc2e43f7cd0642e10bb99164d3e1b43fa21dd4a. This lead to a `NameError` and stop the program.