### PR TITLE
Adding 2 Headers for WebLogic, and adding case options

### DIFF
--- a/ipsourcebypass.py
+++ b/ipsourcebypass.py
@@ -224,7 +224,7 @@ def parseArgs():
     parser.add_argument("-C", "--curl", dest="curl", default=False, required=False, action="store_true", help="Generate curl commands for each request.")
     parser.add_argument("-H", "--header", dest="headers", action="append", default=[], help='arg1 help message')
     parser.add_argument("-S", "--save", dest="save", default=False, required=False, action="store_true", help="Save all HTML responses.")
-    parser.add_argument("-c", "--case", dest="case", default=False, required=False, help="Alternate Upper and Lower case (Case can matter with certains web servers)")
+    parser.add_argument("-c", "--case", dest="case", action='store_true', default=False, required=False, help="Alternate Upper and Lower case (Case can matter with certains web servers)")
     return parser.parse_args()
 
 

--- a/ipsourcebypass.py
+++ b/ipsourcebypass.py
@@ -111,6 +111,16 @@ BYPASS_HEADERS = [
         "header": "True-Client-IP",
         "description": "",
         "references": ["https://docs.aws.amazon.com/en_us/AmazonCloudFront/latest/DeveloperGuide/example-function-add-true-client-ip-header.html"]
+    },
+    {
+        "header": "WL-Proxy-Client-IP",
+        "description": "WebLogic Proxy Header",
+        "references":["https://www.ateam-oracle.com/post/understanding-the-use-of-weblogic-plugin-enabled"]
+    },
+    {
+        "header":"Proxy-Client-IP",
+        "description": "No reference now, just very used",
+        "references":[""]
     }
 ]
 

--- a/ipsourcebypass.py
+++ b/ipsourcebypass.py
@@ -224,6 +224,7 @@ def parseArgs():
     parser.add_argument("-C", "--curl", dest="curl", default=False, required=False, action="store_true", help="Generate curl commands for each request.")
     parser.add_argument("-H", "--header", dest="headers", action="append", default=[], help='arg1 help message')
     parser.add_argument("-S", "--save", dest="save", default=False, required=False, action="store_true", help="Save all HTML responses.")
+    parser.add_argument("-c", "--case", dest="case", default=False, required=False, help="Alternate Upper and Lower case (Case can matter with certains web servers)")
     return parser.parse_args()
 
 
@@ -264,7 +265,11 @@ if __name__ == '__main__':
         # Waits for all the threads to be completed
         with ThreadPoolExecutor(max_workers=min(options.threads, len(BYPASS_HEADERS))) as tp:
             for bph in sorted(BYPASS_HEADERS, key=lambda x:x["header"]):
-                tp.submit(test_bypass, options, proxies, results, bph["header"], options.ip)
+                if options.case:
+                    tp.submit(test_bypass, options, proxies, results, bph["header"].upper(), options.ip)
+                    tp.submit(test_bypass, options, proxies, results, bph["header"].lower(), options.ip)
+                else:
+                    tp.submit(test_bypass, options, proxies, results, bph["header"], options.ip)
 
         # Sorting the results by method name
         results = {key: results[key] for key in sorted(results, key=lambda key: results[key]["length"])}


### PR DESCRIPTION
Hello Podalirius,

I added 2 headers and a case options because some webserver/frameworks are case sensitives

We should also considers theses headers:
```
pc-remote-addr
pragma
proxy
proxy-connection
source-ip
via
x-backend-host
x-bluecoat-via
x-cache-info
x-forwarded-for-ip
x-forwarded-server
x-forward-for
x-from
x-from-ip
x-gateway-host
x-host
x-imforwards
x-ip
xonnection
x-original-host
x-original-ip
x-originally-forwarded-for
x-original-remote-addr
x-original-url
xproxy
x-proxymesh-ip
x-proxyuser-ip
xroxy-connection
x-true-client-ip
z-forwarded-for
```

Also why not create a CSV file instead of writing in the .py file ?